### PR TITLE
Update attivio_module_sdk.md

### DIFF
--- a/attivio_module_sdk.md
+++ b/attivio_module_sdk.md
@@ -29,11 +29,16 @@ This will create a new jar in the target directory of your module.
 
 ## Using your new module
 
-Modules can be added to your Attivio installation (in which case they _must_ be installed on every Attivio host) or added to projects which wish to use them.  To create a project with your new module without installing it, supply the jar to the createproject command as if it were a module name:
+Modules can be added to your Attivio installation (in which case they _must_ be installed on every Attivio host) or added to projects which wish to use them.
+
+To add your module to your installation, the module zip or jar should be installed by running `aie-exec moduleManager`.  This program can list, install, and remove add-on modules.
+
+To create a project with your new module without installing it, supply the jar as an argument to the createproject command as if it were a module name:
 
     createproject -n project-name -m module-dir/target/module-name-1.0-SNAPSHOT.jar
 
-To add your module to your installation, the module zip or jar should be installed by running `aie-exec moduleManager`.  This program can list, install, and remove add-on modules.
+This approach offers limited functionality and is deprecated; we recommend adding your module to the Attivio installation for best results.
+
 
 ## Module resources
 


### PR DESCRIPTION
Updated to reflect information from this log message which is displayed when specifying a module JAR via the -m flag to createproject:

2019-06-05 15:41:40,078 WARN  CreateProject - ATTIVIO-CLI-1 : Installing a module JAR into a project is deprecated due to limited functionality versus installing moduleManager. See documentation at https://answers.attivio.com/display/extranet55 for instructions on how to add modules to an Attivio installation.